### PR TITLE
feat: add GitHub Action for automated release and changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  # Job 1: Run full test suite across all Python versions before releasing
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv and set the Python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
+      - name: Run tests
+        run: uv run pytest tests
+
+  # Job 2: Build, create GitHub Release with auto-changelog, and publish to PyPI
+  release:
+    needs: tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Required to create/update GitHub Release and upload assets
+      id-token: write   # Required for PyPI Trusted Publishers OIDC authentication
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for precise changelog generation
+
+      - name: Install uv and set Python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.9' # Use baseline Python version for building
+
+      - name: Build the package
+        run: uv build
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Optional: You can configure standard PyPI Trusted Publishers.
+        # This action automatically authenticates via OIDC when id-token: write is set
+        # and you have registered GitHub as a Trusted Publisher on pypi.org for this project.
+        # To skip publishing if Trusted Publishers is not set up yet, you can set `skip-existing: true`
+        # or comment this step out until PyPI is configured.
+        with:
+          skip-existing: true

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ logs
 
 ~$*.xlsx
 main.py
+.antigravitycli/


### PR DESCRIPTION
### Description
This pull request adds a GitHub Actions workflow to automate the release process, changelog generation, and PyPI publishing for the `poi` library.

### Key Changes
1. **GitHub Action Workflow**: Created `.github/workflows/release.yml`.
   - **Test Job**: Runs the full test suite (`pytest`) concurrently across all supported Python versions (`3.9`, `3.10`, `3.11`, `3.12`) to ensure codebase health.
   - **Release Job**: Triggered only when a new git tag (`v*`) is pushed and tests pass:
     - Sets up Python and caches dependencies using `astral-sh/setup-uv@v5`.
     - Builds wheels and source distributions using `uv build`.
     - Generates a rich, automated changelog from PRs and commits.
     - Uploads build assets to a new GitHub Release.
     - Publishes package to PyPI securely via **OIDC Trusted Publishers** (`pypa/gh-action-pypi-publish`).

### How to Trigger a Release
1. Update the version number in `pyproject.toml`.
2. Commit and push a tag:
   ```bash
   git tag v1.2.7
   git push origin master
   git push origin v1.2.7
   ```

### Security (OIDC Trusted Publishers)
Instead of using a long-lived, static PyPI API token in repository secrets, the workflow uses OpenID Connect (OIDC) to authenticate. This is PyPI's recommended secure publishing flow.

Instructions on setting up Trusted Publishers in your PyPI project settings are detailed in [walkthrough.md](file:///Users/ryanwang/.gemini/antigravity-cli/brain/2477db63-f21f-44b2-9af4-6b921c4a547b/walkthrough.md).