### PR TITLE
ci: add Deploy Docs workflow to automate documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: write # Required for gh-deploy to push to gh-pages branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dev dependencies
+        run: uv sync --only-group dev
+
+      - name: Deploy documentation
+        run: uv run mkdocs gh-deploy --force


### PR DESCRIPTION
Automates documentation building and deployment to GitHub Pages (gh-pages) whenever changes are merged into the master branch.