### PR TITLE
fix: write integers beyond 2^53 as text to preserve precision

### DIFF
--- a/poi/writer.py
+++ b/poi/writer.py
@@ -11,6 +11,19 @@ from xlsxwriter.worksheet import Worksheet
 
 logger = logging.getLogger(__name__)
 
+# Excel stores numbers as IEEE 754 doubles, so integers outside the range
+# [-(2**53 - 1), 2**53 - 1] cannot be represented exactly and silently lose
+# precision (e.g. 222222222222222222222222222222 -> 2.222222222222222E+29).
+# Write such integers as text instead to preserve every digit.
+MAX_SAFE_INTEGER = 2**53 - 1
+
+
+def _coerce_large_int(value: Any) -> Any:
+    # `type(value) is int` deliberately excludes bool (a subclass of int).
+    if type(value) is int and not -MAX_SAFE_INTEGER <= value <= MAX_SAFE_INTEGER:
+        return str(value)
+    return value
+
 
 class WorkBook(Protocol):
     def add_format(self, format: dict[str, Any]) -> Format: ...
@@ -86,12 +99,18 @@ class Writer:
         return args
 
     def write(self, *args: Any) -> None:
-        args = self._path_args(args)
-        self.worksheet.write(*args)
+        out = list(self._path_args(args))
+        # out: (row, col, value, [format])
+        if len(out) >= 3:
+            out[2] = _coerce_large_int(out[2])
+        self.worksheet.write(*out)
 
     def merge_range(self, *args: Any) -> None:
-        args = self._path_args(args)
-        self.worksheet.merge_range(*args)
+        out = list(self._path_args(args))
+        # out: (first_row, first_col, last_row, last_col, value, [format])
+        if len(out) >= 5:
+            out[4] = _coerce_large_int(out[4])
+        self.worksheet.merge_range(*out)
 
     def insert_image(self, *args: Any) -> None:
         self.worksheet.insert_image(*args)

--- a/tests/test_poi.py
+++ b/tests/test_poi.py
@@ -1,9 +1,22 @@
 import datetime
+import io
 import os
+import zipfile
 from pathlib import Path
 from typing import NamedTuple
 
 from poi import Cell, Col, Image, Row, Sheet, Table
+
+
+def _sheet_xml(sheet: Sheet) -> str:
+    data = sheet.write_to_bytes_io().read()
+    z = zipfile.ZipFile(io.BytesIO(data))
+    xml = z.read("xl/worksheets/sheet1.xml").decode()
+    try:
+        shared = z.read("xl/sharedStrings.xml").decode()
+    except KeyError:
+        shared = ""
+    return xml + shared
 
 
 def assert_match_snapshot(sheet: Sheet, snapshot):
@@ -335,3 +348,39 @@ def test_dynamic_table_style_numeric(pytestconfig):
     )
     res = sheet.write_to_bytes_io()
     assert res is not None
+
+
+def test_large_int_written_as_text():
+    # Integers beyond 2**53 - 1 lose precision when stored as Excel numbers,
+    # so they must be written as text to keep every digit intact.
+    big = 222222222222222222222222222222
+    negative_big = -(2**63)
+    safe = 2**53 - 1  # largest exactly representable integer
+
+    class Record(NamedTuple):
+        value: int
+
+    sheet = Sheet(
+        root=Col(
+            children=[
+                Row(children=[Cell(big), Cell(negative_big), Cell(safe)]),
+                Table(data=[Record(value=big)], columns=[("value", "Value")]),
+            ]
+        )
+    )
+    content = _sheet_xml(sheet)
+
+    # Exact digits preserved, no scientific-notation rounding.
+    assert str(big) in content
+    assert str(negative_big) in content
+    assert "E+" not in content and "e+" not in content
+    # Safe integers stay numeric (not stringified).
+    assert f"<v>{safe}</v>" in content
+
+
+def test_bool_and_float_unaffected_by_large_int_handling():
+    sheet = Sheet(root=Col(children=[Row(children=[Cell(True), Cell(1.5), Cell(42)])]))
+    xml = _sheet_xml(sheet)
+    assert 't="b"' in xml  # bool stays a boolean cell
+    assert "<v>1.5</v>" in xml  # float stays numeric
+    assert "<v>42</v>" in xml  # small int stays numeric


### PR DESCRIPTION
## Problem

Excel stores numbers as IEEE 754 doubles, so integers outside `[-(2**53 - 1), 2**53 - 1]` cannot be represented exactly and silently lose precision. For example, `222222222222222222222222222222` was written as `2.222222222222222E+29`, discarding every trailing digit.

## Fix

Coerce out-of-range integers to text at the `Writer` boundary (`Writer.write` / `Writer.merge_range`), which is the single point all writes flow through. This covers both `Cell` and `Table` data paths and preserves every digit.

```python
MAX_SAFE_INTEGER = 2**53 - 1

def _coerce_large_int(value):
    # type(value) is int deliberately excludes bool (a subclass of int).
    if type(value) is int and not -MAX_SAFE_INTEGER <= value <= MAX_SAFE_INTEGER:
        return str(value)
    return value
```

## Behavior

- Integers beyond `±(2**53 - 1)` are stored as text, keeping all digits intact.
- Integers within the safe range stay numeric — no change.
- `bool` (a subclass of `int`) and `float` are unaffected.

> Trade-off: text-stored integers may show Excel's green "number stored as text" triangle. That is the necessary cost of preserving full precision, since integers of this magnitude cannot be represented exactly by Excel's numeric type.

## Tests

Added `test_large_int_written_as_text` and `test_bool_and_float_unaffected_by_large_int_handling`, which inspect the generated XML directly. Full suite (23 tests), ruff, and mypy all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)